### PR TITLE
Feat/navbar: `NavBar`, `NavButton` 컴포넌트 작성

### DIFF
--- a/src/assets/common-home-click.svg
+++ b/src/assets/common-home-click.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24" viewBox="0 0 24 24" width="24" focusable="false" style="pointer-events: none; display: block; width: 100%; height: 100%; fill: #045ADC"><g><path d="M4 21V10.08l8-6.96 8 6.96V21h-6v-6h-4v6H4z"></path></g></svg>

--- a/src/assets/common-home.svg
+++ b/src/assets/common-home.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24" viewBox="0 0 24 24" width="24" focusable="false" style="pointer-events: none; display: block; width: 100%; height: 100%;"><g><path d="M4 21V10.08l8-6.96 8 6.96V21h-6v-6h-4v6H4z"></path></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" enable-background="new 0 0 24 24" height="24" viewBox="0 0 24 24" width="24"><path d="M12,4.44l7,6.09V20h-4v-5v-1h-1h-4H9v1v5H5v-9.47L12,4.44 M12,3.12l-8,6.96V21h6v-6h4v6h6V10.08L12,3.12L12,3.12z"></path></svg>

--- a/src/components/NavButton.tsx
+++ b/src/components/NavButton.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface NavButtonProps {
+  src: string;
+  title: string;
+}
+
+function NavButton({ src, title }: NavButtonProps) {
+  const handleNav = (e: React.MouseEvent<HTMLButtonElement>) => {
+    const altText = (e.currentTarget.querySelector('img') as HTMLImageElement)
+      ?.alt;
+    console.log(altText);
+  };
+
+  return (
+    <Button type="button" onClick={handleNav}>
+      <img src={src} alt={title} />
+      <p>{title}</p>
+    </Button>
+  );
+}
+
+export default NavButton;
+
+const Button = styled.button`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-evenly;
+  width: 6.0938rem;
+  height: 3rem;
+  border: none;
+  background-color: transparent;
+  cursor: pointer;
+`;

--- a/src/layouts/NavBar.tsx
+++ b/src/layouts/NavBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import NavButton from '../components/NavButton';
 import commonHome from '../assets/common-home.svg';
-import commonHomeClick from '../assets/common-home-click.svg';
+// import commonHomeClick from '../assets/common-home-click.svg';
 import commonShorts from '../assets/common-shorts.svg';
 import commonSubscribe from '../assets/common-subscribe.svg';
 import commonMe from '../assets/common-me.svg';
@@ -25,4 +25,13 @@ const NavBox = styled.nav`
   justify-content: space-between;
   width: 24.375rem;
   height: 3.0625rem;
+  position: fixed;
+  bottom: 0.625rem;
 `;
+
+/* 추후 화면 설정
+const Back = styled.div`
+  position: relative;
+  height: 100vh;
+`;
+*/

--- a/src/layouts/NavBar.tsx
+++ b/src/layouts/NavBar.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+import NavButton from '../components/NavButton';
+import commonHome from '../assets/common-home.svg';
+import commonHomeClick from '../assets/common-home-click.svg';
+import commonShorts from '../assets/common-shorts.svg';
+import commonSubscribe from '../assets/common-subscribe.svg';
+import commonMe from '../assets/common-me.svg';
+
+function NavBar() {
+  return (
+    <NavBox>
+      <NavButton src={commonHome} title={'홈'} />
+      <NavButton src={commonShorts} title={'Shorts'} />
+      <NavButton src={commonSubscribe} title={'구독'} />
+      <NavButton src={commonMe} title={'보관함'} />
+    </NavBox>
+  );
+}
+
+export default NavBar;
+
+const NavBox = styled.nav`
+  display: flex;
+  justify-content: space-between;
+  width: 24.375rem;
+  height: 3.0625rem;
+`;


### PR DESCRIPTION
# 내용
styled components 이용하여 CSS 작업

# 이미지 (옵션)
없음

# 달성도
1. NavButton
  - `onClick` 이벤트 이용한 이미지 alt 속성을 찾았습니다. (nav click 이벤트에 이용)
  - src, title props 전달하여 컴포넌트 재사용할 수 있도록 하였습니다.
  - 하단 고정 `position: fixed` css 작업하였습니다.

2. NavBar
  - `NavButton` 컴포넌트 불러와서 NavBar 구현하였습니다.

- 상위요소 추후 작성 예정입니다.
  ```
  position: relative;
  height: 100vh;
  ```

3. assets 추가
- 홈 버튼 click 이벤트 assets 추가