### PR TITLE
Feat/detail: 상세페이지 내 모바일 시안 및 데스크탑 관련 영상 스크롤 개선

### DIFF
--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -72,7 +72,7 @@ function DetailPage() {
               </ContentDetail>
             </VideoContent>
           </MainBox>
-          <div>
+          <ScrollBox>
             {detailData &&
               detailData.map((item: Item) => (
                 <SubBox key={item.id.videoId}>
@@ -93,7 +93,7 @@ function DetailPage() {
                   </SubTextBox>
                 </SubBox>
               ))}
-          </div>
+          </ScrollBox>
         </Box>
       )}
     </>
@@ -165,6 +165,13 @@ const ContentDetail = styled.dl`
   }
 `;
 
+const ScrollBox = styled.div`
+  @media ${(props) => props.theme.laptop} {
+    height: 100vh;
+    overflow-y: auto;
+  }
+`;
+
 const SubBox = styled.div`
   display: flex;
   gap: 0.5rem;
@@ -216,14 +223,11 @@ const SubTextBox = styled.div`
 `;
 
 const SubTitleText = styled.p`
+  overflow: hidden;
+  display: -webkit-box;
   font-weight: 600;
-
-  @media ${(props) => props.theme.mobile} {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    -webkit-box-orient: vertical;
-  }
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
 `;
 
 const SubTimeBox = styled.div`

--- a/src/pages/DetailPage.tsx
+++ b/src/pages/DetailPage.tsx
@@ -86,7 +86,9 @@ function DetailPage() {
                     <SubTitleText>{item.snippet.title} </SubTitleText>
                     <SubTimeBox>
                       <p>{item.snippet.channelTitle}</p>
-                      <p>{item.snippet.publishedAt.slice(0, 10)}</p>
+                      <TimeContent>
+                        {item.snippet.publishedAt.slice(0, 10)}
+                      </TimeContent>
                     </SubTimeBox>
                   </SubTextBox>
                 </SubBox>
@@ -167,6 +169,11 @@ const SubBox = styled.div`
   display: flex;
   gap: 0.5rem;
   margin-top: var(--primary-margin);
+
+  @media ${(props) => props.theme.mobile} {
+    display: flex;
+    flex-direction: column;
+  }
 `;
 
 const SubImgBox = styled.div`
@@ -177,6 +184,24 @@ const SubImgBox = styled.div`
     height: 5.875rem;
     object-fit: cover;
     border-radius: 0.625rem;
+
+    @media ${(props) => props.theme.mobile} {
+      width: 100%;
+      height: 20vh;
+      object-fit: unset;
+
+      @media (min-width: 26.875rem) {
+        height: 25vh;
+      }
+
+      @media (min-width: 28.75rem) {
+        height: 30vh;
+      }
+
+      @media (min-width: 35rem) {
+        height: 40vh;
+      }
+    }
   }
 `;
 
@@ -192,10 +217,23 @@ const SubTextBox = styled.div`
 
 const SubTitleText = styled.p`
   font-weight: 600;
+
+  @media ${(props) => props.theme.mobile} {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 1;
+    -webkit-box-orient: vertical;
+  }
 `;
 
 const SubTimeBox = styled.div`
   display: flex;
   flex-direction: column;
   font-size: 0.875rem;
+`;
+
+const TimeContent = styled.p`
+  @media ${(props) => props.theme.mobile} {
+    display: none;
+  }
 `;


### PR DESCRIPTION
# 내용
상세페이지 내 모바일 시안 및 데스크탑 관련 영상 스크롤 개선하였습니다.

# 이미지 (옵션)
![image](https://github.com/twelive/final-project/assets/134567469/a80c8e5b-00fd-471b-88d9-b96d8cf41a33)

# 달성도
- 관련 영상 목록 크기 조절하였습니다.
- 관련 영상 목록 overflow시 scroll 구현
